### PR TITLE
Update Run.py

### DIFF
--- a/CommandLine/Run.py
+++ b/CommandLine/Run.py
@@ -83,4 +83,4 @@ class Run(Program):
                     not parserArgs.nofill, not parserArgs.border, parserArgs.belief,
                     parserArgs.binary, not parserArgs.no_separation, parserArgs.edges,
                     parserArgs.colorize, True, parserArgs.track, parserArgs.overlay,
-                    parserArgs.gif, parserArgs.batch, parserArgs.analyzeg)
+                    parserArgs.gif, parserArgs.batch, parserArgs.analyze)


### PR DESCRIPTION
I was getting the error "AttributeError: 'Namespace' object has no attribute 'analyzeg'" and I believe the change below fixes it.

Line 86 of CommandLine/Run.py 'parserArgs.analyzeg' to 'parserArgs.analyze'

